### PR TITLE
feat(superuser): Test-Push an alle User mit aktiver Subscription

### DIFF
--- a/app/pages/superuser.vue
+++ b/app/pages/superuser.vue
@@ -60,13 +60,31 @@ async function runSeed() {
 const toast = useToast()
 const pushTestLoading = ref(false)
 const pushTestError = ref<string | null>(null)
+const pushTestConfirmOpen = ref(false)
+
+type PushTestResult = {
+  ok: boolean
+  stats: {
+    subscriptions: number
+    users: number
+    sent: number
+    expired: number
+    failed: number
+  }
+}
 
 async function runPushTest() {
+  pushTestConfirmOpen.value = false
   pushTestLoading.value = true
   pushTestError.value = null
   try {
-    await $fetch('/api/superuser/test-push', { method: 'POST' })
-    toast.add({ title: 'Test-Push gesendet', description: 'Sollte gleich auf deinem Gerät erscheinen.', color: 'success' })
+    const res = await $fetch<PushTestResult>('/api/superuser/test-push', { method: 'POST' })
+    const { sent, failed, expired, users, subscriptions } = res.stats
+    toast.add({
+      title: 'Test-Push versendet',
+      description: `${sent}/${subscriptions} Subscriptions (${users} User) · ${expired} abgelaufen · ${failed} Fehler`,
+      color: failed > 0 ? 'warning' : 'success',
+    })
   }
   catch (err: unknown) {
     pushTestError.value = err instanceof Error ? err.message : 'Unbekannter Fehler'
@@ -214,21 +232,23 @@ async function runPushTest() {
     </div>
 
     <!-- Push-Test -->
-    <div class="rounded-[--ui-radius] border border-default p-6 space-y-5 mt-6">
+    <div class="rounded-[--ui-radius] border border-error/40 p-6 space-y-5 mt-6">
       <div>
         <h2 class="font-display font-semibold text-highlighted text-base">
-          Push-Test
+          Push-Test an alle
         </h2>
         <p class="text-sm text-muted mt-1">
-          Sendet eine Test-Push-Notification an alle Geräte, auf denen du selbst Push aktiviert hast.
+          Sendet eine Test-Push-Notification an <span class="text-error font-medium">alle User mit aktivierter Push-Subscription</span>.
         </p>
       </div>
 
       <UButton
-        label="Test-Push senden"
+        label="Test-Push an alle senden"
         icon="i-ph-bell-ringing-bold"
+        color="error"
+        variant="subtle"
         :loading="pushTestLoading"
-        @click="runPushTest"
+        @click="pushTestConfirmOpen = true"
       />
 
       <UAlert
@@ -240,5 +260,40 @@ async function runPushTest() {
         :description="pushTestError"
       />
     </div>
+
+    <UModal v-model:open="pushTestConfirmOpen">
+      <template #content>
+        <div class="p-6 space-y-5">
+          <div class="flex items-start gap-3">
+            <UIcon
+              name="i-ph-warning-bold"
+              class="size-6 shrink-0 text-error"
+            />
+            <div>
+              <h3 class="font-display font-semibold text-highlighted text-base">
+                Test-Push an alle User senden?
+              </h3>
+              <p class="text-sm text-muted mt-1">
+                Diese Aktion versendet eine Test-Benachrichtigung an <span class="text-error font-medium">alle User mit aktivierter Push-Subscription</span>. Nur zum Testen verwenden.
+              </p>
+            </div>
+          </div>
+          <div class="flex justify-end gap-2 pt-2 border-t border-default">
+            <UButton
+              label="Abbrechen"
+              color="neutral"
+              variant="ghost"
+              @click="pushTestConfirmOpen = false"
+            />
+            <UButton
+              label="Ja, an alle senden"
+              color="error"
+              :loading="pushTestLoading"
+              @click="runPushTest"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
   </UContainer>
 </template>

--- a/server/api/superuser/test-push.post.ts
+++ b/server/api/superuser/test-push.post.ts
@@ -2,13 +2,13 @@ import { requireSuperuser } from '~~/server/utils/auth'
 import { pushService } from '~~/server/notifications/push'
 
 export default defineEventHandler(async (event) => {
-  const session = await requireSuperuser(event)
+  await requireSuperuser(event)
 
-  await pushService.sendPushToUser(session.user.id, {
+  const stats = await pushService.sendPushToAll({
     title: 'BTC Races — Test',
     body: 'Push-Test erfolgreich. Wenn du das siehst, läuft alles.',
     url: '/',
   })
 
-  return { ok: true }
+  return { ok: true, stats }
 })

--- a/server/notifications/push.ts
+++ b/server/notifications/push.ts
@@ -118,8 +118,52 @@ async function sendPushToUsers(userIds: number[], payload: PushPayload): Promise
   }
 }
 
+export interface PushBroadcastStats {
+  subscriptions: number
+  users: number
+  sent: number
+  expired: number
+  failed: number
+}
+
+/**
+ * Sendet eine Push-Notification an ALLE registrierten Subscriptions im System.
+ * Gibt detaillierte Statistiken zurück. Nur für Admin-/Test-Zwecke gedacht.
+ */
+async function sendPushToAll(payload: PushPayload): Promise<PushBroadcastStats> {
+  const { db, schema } = await import('hub:db')
+
+  const subscriptions = await db.select().from(schema.pushSubscriptions)
+  const uniqueUsers = new Set(subscriptions.map(s => s.userId))
+
+  let sent = 0
+  let expired = 0
+  let failed = 0
+
+  for (const sub of subscriptions) {
+    try {
+      await sendPush(sub, payload)
+      sent++
+    }
+    catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      if (message === 'subscription expired') expired++
+      else failed++
+    }
+  }
+
+  return {
+    subscriptions: subscriptions.length,
+    users: uniqueUsers.size,
+    sent,
+    expired,
+    failed,
+  }
+}
+
 export const pushService = {
   sendPush,
   sendPushToUser,
   sendPushToUsers,
+  sendPushToAll,
 }


### PR DESCRIPTION
Der Push-Test-Button auf der Superuser-Seite versendet jetzt an alle registrierten Push-Subscriptions statt nur an den angemeldeten Superuser. Das erleichtert Infrastruktur-Tests (VAPID, Provider-Zustellung auf unterschiedlichen Devices) und sichert das Feature durch einen Bestätigungsdialog plus roten Warn-Stil gegen versehentliche Auslösung ab. Die API gibt eine Versand-Statistik zurück (sent/expired/failed), die im Toast angezeigt wird.

Closes #70

Made-with: Cursor