### PR TITLE
feat(superuser): Member-Admin-Übersicht für Superuser

### DIFF
--- a/app/pages/superuser/index.vue
+++ b/app/pages/superuser/index.vue
@@ -106,6 +106,12 @@ async function runPushTest() {
         Notifications
       </NuxtLink>
       <NuxtLink
+        to="/superuser/members"
+        class="px-4 py-2 text-sm font-medium text-muted hover:text-highlighted transition-colors border-b-2 border-transparent"
+      >
+        Member
+      </NuxtLink>
+      <NuxtLink
         to="/superuser"
         class="px-4 py-2 text-sm font-medium text-highlighted border-b-2 border-primary"
       >

--- a/app/pages/superuser/members.vue
+++ b/app/pages/superuser/members.vue
@@ -1,0 +1,487 @@
+<script setup lang="ts">
+import type { MemberAdminOverviewItem, MemberRegistrationItem } from '~~/server/members/admin-overview'
+
+definePageMeta({ title: 'Superuser — Member' })
+
+const { session } = useUserSession()
+if (session.value?.user?.role !== 'superuser') {
+  await navigateTo('/')
+}
+
+const { data: members, status: loadStatus } = await useFetch<MemberAdminOverviewItem[]>('/api/superuser/members')
+
+// ── Filter ───────────────────────────────────────────────────────────
+const search = ref('')
+const roleFilter = ref<'all' | 'member' | 'admin' | 'superuser'>('all')
+const pushFilter = ref<'all' | 'yes' | 'no'>('all')
+const syncFilter = ref<'all' | 'synced' | 'stale' | 'never'>('all')
+
+const roleOptions = [
+  { value: 'all', label: 'Alle Rollen' },
+  { value: 'member', label: 'Member' },
+  { value: 'admin', label: 'Admin' },
+  { value: 'superuser', label: 'Superuser' },
+]
+const pushOptions = [
+  { value: 'all', label: 'Push: alle' },
+  { value: 'yes', label: 'Push aktiv' },
+  { value: 'no', label: 'Ohne Push' },
+]
+const syncOptions = [
+  { value: 'all', label: 'Sync: alle' },
+  { value: 'synced', label: 'Synchronisiert' },
+  { value: 'stale', label: 'Veraltet' },
+  { value: 'never', label: 'Nie synchronisiert' },
+]
+
+const filteredMembers = computed(() => {
+  return (members.value ?? []).filter((m) => {
+    if (roleFilter.value !== 'all' && m.role !== roleFilter.value) return false
+    if (pushFilter.value === 'yes' && m.pushDeviceCount === 0) return false
+    if (pushFilter.value === 'no' && m.pushDeviceCount > 0) return false
+    if (syncFilter.value !== 'all' && m.syncState !== syncFilter.value) return false
+    if (search.value) {
+      const q = search.value.toLowerCase()
+      const name = `${m.firstName ?? ''} ${m.lastName ?? ''}`.toLowerCase()
+      return name.includes(q) || m.email.toLowerCase().includes(q)
+    }
+    return true
+  })
+})
+
+// ── Display-Helfer ───────────────────────────────────────────────────
+const roleLabels: Record<MemberAdminOverviewItem['role'], string> = {
+  member: 'Member',
+  admin: 'Admin',
+  superuser: 'Superuser',
+}
+function roleColor(role: MemberAdminOverviewItem['role']) {
+  return ({ member: 'neutral', admin: 'info', superuser: 'primary' } as const)[role]
+}
+
+const syncLabels: Record<MemberAdminOverviewItem['syncState'], string> = {
+  synced: 'Synchronisiert',
+  stale: 'Veraltet',
+  never: 'Nie',
+}
+function syncColor(state: MemberAdminOverviewItem['syncState']) {
+  return ({ synced: 'success', stale: 'warning', never: 'neutral' } as const)[state]
+}
+
+function fullName(m: MemberAdminOverviewItem) {
+  return [m.firstName, m.lastName].filter(Boolean).join(' ') || '–'
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '–'
+  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })
+}
+
+// ── Detail-Modal ─────────────────────────────────────────────────────
+const selected = ref<MemberAdminOverviewItem | null>(null)
+const detailOpen = ref(false)
+const registrations = ref<MemberRegistrationItem[]>([])
+const registrationsLoading = ref(false)
+
+async function openDetail(member: MemberAdminOverviewItem) {
+  selected.value = member
+  detailOpen.value = true
+  registrations.value = []
+  registrationsLoading.value = true
+  try {
+    registrations.value = await $fetch<MemberRegistrationItem[]>(`/api/superuser/members/${member.id}/registrations`)
+  }
+  finally {
+    registrationsLoading.value = false
+  }
+}
+</script>
+
+<template>
+  <UContainer class="py-10 lg:py-14 max-w-6xl">
+    <div class="mb-8">
+      <h1 class="font-display font-semibold text-highlighted text-2xl">
+        Superuser
+      </h1>
+      <p class="text-sm text-muted mt-1">
+        Systemfunktionen
+      </p>
+    </div>
+
+    <!-- Sub-Navigation -->
+    <div class="flex gap-2 mb-8 border-b border-default">
+      <NuxtLink
+        to="/superuser/notifications"
+        class="px-4 py-2 text-sm font-medium text-muted hover:text-highlighted transition-colors border-b-2 border-transparent"
+      >
+        Notifications
+      </NuxtLink>
+      <NuxtLink
+        to="/superuser/members"
+        class="px-4 py-2 text-sm font-medium text-highlighted border-b-2 border-primary"
+      >
+        Member
+      </NuxtLink>
+      <NuxtLink
+        to="/superuser"
+        class="px-4 py-2 text-sm font-medium text-muted hover:text-highlighted transition-colors border-b-2 border-transparent"
+      >
+        System
+      </NuxtLink>
+    </div>
+
+    <!-- Filter -->
+    <div class="flex flex-wrap items-end gap-3 mb-4">
+      <UFormField
+        label="Suche"
+        size="sm"
+        class="w-full sm:flex-1 sm:min-w-[16rem]"
+      >
+        <UInput
+          v-model="search"
+          icon="i-ph-magnifying-glass"
+          placeholder="Name oder E-Mail"
+          class="w-full"
+        />
+      </UFormField>
+      <UFormField
+        label="Rolle"
+        size="sm"
+        class="basis-[calc(50%-0.375rem)] sm:basis-auto sm:w-48"
+      >
+        <USelect
+          v-model="roleFilter"
+          :items="roleOptions"
+          value-key="value"
+          class="w-full"
+        />
+      </UFormField>
+      <UFormField
+        label="Push"
+        size="sm"
+        class="basis-[calc(50%-0.375rem)] sm:basis-auto sm:w-48"
+      >
+        <USelect
+          v-model="pushFilter"
+          :items="pushOptions"
+          value-key="value"
+          class="w-full"
+        />
+      </UFormField>
+      <UFormField
+        label="Sync-Status"
+        size="sm"
+        class="basis-[calc(50%-0.375rem)] sm:basis-auto sm:w-48"
+      >
+        <USelect
+          v-model="syncFilter"
+          :items="syncOptions"
+          value-key="value"
+          class="w-full"
+        />
+      </UFormField>
+    </div>
+
+    <p class="text-xs text-muted mb-3">
+      {{ filteredMembers.length }} von {{ members?.length ?? 0 }} Member
+    </p>
+
+    <!-- Loading -->
+    <div
+      v-if="loadStatus === 'pending' && !members"
+      class="space-y-3"
+    >
+      <USkeleton
+        v-for="i in 6"
+        :key="i"
+        class="h-14 w-full"
+      />
+    </div>
+
+    <!-- Leer -->
+    <div
+      v-else-if="!filteredMembers.length"
+      class="text-center py-20 text-muted space-y-3"
+    >
+      <UIcon
+        name="i-ph-users"
+        class="size-12 mx-auto opacity-60"
+      />
+      <p class="font-medium text-highlighted">
+        Keine Member gefunden
+      </p>
+      <p class="text-sm">
+        Keine Member passen zu den aktuellen Filtern.
+      </p>
+    </div>
+
+    <!-- Tabelle -->
+    <div
+      v-else
+      class="rounded-[--ui-radius] border border-default overflow-hidden overflow-x-auto"
+    >
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-elevated border-b border-default">
+            <th class="px-4 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
+              Member
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
+              Rolle
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
+              Status
+            </th>
+            <th class="px-4 py-3 text-center text-xs font-medium text-muted uppercase tracking-wider">
+              Push
+            </th>
+            <th class="px-4 py-3 text-center text-xs font-medium text-muted uppercase tracking-wider">
+              Anmeldungen
+            </th>
+            <th class="px-4 py-3 text-center text-xs font-medium text-muted uppercase tracking-wider">
+              Startpass
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
+              E-Mail
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
+              Sync
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-default">
+          <tr
+            v-for="m in filteredMembers"
+            :key="m.id"
+            class="hover:bg-elevated/50 transition-colors cursor-pointer"
+            @click="openDetail(m)"
+          >
+            <td class="px-4 py-3 whitespace-nowrap">
+              <div class="flex items-center gap-3">
+                <UAvatar
+                  :src="m.avatarUrl ?? undefined"
+                  :alt="fullName(m)"
+                  size="sm"
+                />
+                <span class="font-medium text-highlighted">{{ fullName(m) }}</span>
+              </div>
+            </td>
+            <td class="px-4 py-3">
+              <UBadge
+                :label="roleLabels[m.role]"
+                :color="roleColor(m.role)"
+                variant="subtle"
+                size="sm"
+              />
+            </td>
+            <td class="px-4 py-3">
+              <UBadge
+                v-if="m.membershipStatus"
+                :label="m.membershipStatus === 'active' ? 'Aktiv' : 'Inaktiv'"
+                :color="m.membershipStatus === 'active' ? 'success' : 'neutral'"
+                variant="soft"
+                size="sm"
+              />
+              <span
+                v-else
+                class="text-dimmed"
+              >–</span>
+            </td>
+            <td class="px-4 py-3 text-center">
+              <span
+                v-if="m.pushDeviceCount > 0"
+                class="inline-flex items-center gap-1 text-highlighted"
+              >
+                <UIcon
+                  name="i-ph-bell-ringing"
+                  class="size-4 text-primary"
+                />
+                {{ m.pushDeviceCount }}
+              </span>
+              <span
+                v-else
+                class="text-dimmed"
+              >–</span>
+            </td>
+            <td class="px-4 py-3 text-center text-muted tabular-nums">
+              {{ m.registrationCount }}
+            </td>
+            <td class="px-4 py-3 text-center">
+              <UIcon
+                v-if="m.hasLadvStartpass"
+                name="i-ph-check-circle-fill"
+                class="size-5 text-success"
+              />
+              <UIcon
+                v-else
+                name="i-ph-minus"
+                class="size-4 text-dimmed"
+              />
+            </td>
+            <td class="px-4 py-3 text-muted">
+              {{ m.email }}
+            </td>
+            <td class="px-4 py-3 whitespace-nowrap">
+              <div class="flex items-center gap-2">
+                <UBadge
+                  :label="syncLabels[m.syncState]"
+                  :color="syncColor(m.syncState)"
+                  variant="subtle"
+                  size="sm"
+                />
+                <span class="text-xs text-dimmed">{{ formatDate(m.lastSyncedAt) }}</span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Detail-Modal -->
+    <UModal
+      v-model:open="detailOpen"
+      :title="selected ? fullName(selected) : 'Member'"
+    >
+      <template #body>
+        <div
+          v-if="selected"
+          class="space-y-6"
+        >
+          <!-- Stammdaten -->
+          <div class="grid grid-cols-2 gap-x-6 gap-y-4 text-sm">
+            <div>
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                Rolle
+              </p>
+              <UBadge
+                :label="roleLabels[selected.role]"
+                :color="roleColor(selected.role)"
+                variant="subtle"
+                size="sm"
+              />
+            </div>
+            <div>
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                Mitgliedsstatus
+              </p>
+              <p class="text-highlighted">
+                {{ selected.membershipStatus === 'active' ? 'Aktiv' : selected.membershipStatus === 'inactive' ? 'Inaktiv' : '–' }}
+              </p>
+            </div>
+            <div class="col-span-2">
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                E-Mail
+              </p>
+              <p class="text-highlighted break-all">
+                {{ selected.email }}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                Mitgliedsnummer
+              </p>
+              <p class="text-highlighted">
+                {{ selected.membershipNumber ?? '–' }}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                Letzter Sync
+              </p>
+              <p class="text-highlighted">
+                {{ formatDate(selected.lastSyncedAt) }}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                Push-Geräte
+              </p>
+              <p class="text-highlighted">
+                {{ selected.pushDeviceCount }}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                LADV-Startpass
+              </p>
+              <p class="text-highlighted">
+                {{ selected.hasLadvStartpass ? 'Ja' : 'Nein' }}
+              </p>
+            </div>
+            <div
+              v-if="selected.sections?.length"
+              class="col-span-2"
+            >
+              <p class="text-xs text-muted uppercase tracking-wider mb-1">
+                Sektionen
+              </p>
+              <div class="flex flex-wrap gap-1">
+                <UBadge
+                  v-for="s in selected.sections"
+                  :key="s"
+                  :label="s"
+                  color="neutral"
+                  variant="soft"
+                  size="xs"
+                />
+              </div>
+            </div>
+          </div>
+
+          <!-- Event-Anmeldungen -->
+          <div>
+            <p class="text-xs text-muted uppercase tracking-wider mb-2">
+              Event-Anmeldungen ({{ selected.registrationCount }})
+            </p>
+            <div
+              v-if="registrationsLoading"
+              class="space-y-2"
+            >
+              <USkeleton
+                v-for="i in 3"
+                :key="i"
+                class="h-9 w-full"
+              />
+            </div>
+            <p
+              v-else-if="!registrations.length"
+              class="text-sm text-muted"
+            >
+              Keine Anmeldungen.
+            </p>
+            <div
+              v-else
+              class="rounded-[--ui-radius] border border-default divide-y divide-default"
+            >
+              <div
+                v-for="r in registrations"
+                :key="r.eventId"
+                class="flex items-center justify-between px-3 py-2 text-sm"
+              >
+                <NuxtLink
+                  :to="`/${r.eventSlug}`"
+                  class="text-highlighted hover:text-primary transition-colors inline-flex items-center gap-1 min-w-0"
+                >
+                  <span class="truncate">{{ r.eventName }}</span>
+                  <UIcon
+                    name="i-ph-arrow-up-right"
+                    class="size-3.5 shrink-0 opacity-60"
+                  />
+                </NuxtLink>
+                <div class="flex items-center gap-3 shrink-0">
+                  <span class="text-xs text-muted">{{ formatDate(r.eventDate) }}</span>
+                  <UBadge
+                    :label="r.status"
+                    color="neutral"
+                    variant="soft"
+                    size="xs"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </UContainer>
+</template>

--- a/app/pages/superuser/notifications.vue
+++ b/app/pages/superuser/notifications.vue
@@ -195,6 +195,12 @@ function toggleExpand(id: number) {
         Notifications
       </NuxtLink>
       <NuxtLink
+        to="/superuser/members"
+        class="px-4 py-2 text-sm font-medium text-muted hover:text-highlighted transition-colors border-b-2 border-transparent"
+      >
+        Member
+      </NuxtLink>
+      <NuxtLink
         to="/superuser"
         class="px-4 py-2 text-sm font-medium text-muted hover:text-highlighted transition-colors border-b-2 border-transparent"
       >

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -36,6 +36,31 @@ deadline check, diff, non-trivial transform) is an *extraction* signal, not a te
 signal. Move it to `server/utils/`, `shared/utils/` or the owning module, then
 test it there. The handler/composable stays thin.
 
+## How persistence modules get the DB
+
+Persistence modules **never import `hub:db` directly**. They take the Drizzle DB as
+their **first parameter** (`db: AppDb`), where `AppDb = typeof hubDb` (declared in
+`server/registration/persistence.ts`; declare the same `type AppDb = typeof hubDb`
+locally in a new module area). The API handler injects the real DB from `hub:db`;
+the test injects the in-memory `createTestDb()` instance. Same code path, no mock —
+this dependency injection is the whole reason the module is testable.
+
+```ts
+// module — server/<area>/<thing>.ts
+import type { db as hubDb } from 'hub:db'
+import * as schema from '~~/server/db/schema'
+type AppDb = typeof hubDb
+export async function buildOverview(db: AppDb) { /* real Drizzle queries */ }
+
+// handler — thin adapter, no logic
+import { db } from 'hub:db'
+export default defineEventHandler(() => buildOverview(db))
+
+// test — real DB, public API
+const { db } = await createTestDb()
+expect(await buildOverview(db)).toEqual(/* … */)
+```
+
 ## Conventions
 
 - Layout mirrors the source tree: `test/unit/server/registration/…`,

--- a/server/api/superuser/members.get.ts
+++ b/server/api/superuser/members.get.ts
@@ -1,0 +1,8 @@
+import { db } from 'hub:db'
+import { getMemberAdminOverview } from '~~/server/members/admin-overview'
+import { requireSuperuser } from '~~/server/utils/auth'
+
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+  return getMemberAdminOverview(db, new Date())
+})

--- a/server/api/superuser/members/[id]/registrations.get.ts
+++ b/server/api/superuser/members/[id]/registrations.get.ts
@@ -1,0 +1,10 @@
+import { db } from 'hub:db'
+import { getMemberRegistrations } from '~~/server/members/admin-overview'
+import { requireSuperuser } from '~~/server/utils/auth'
+import { requireNumericIdParam } from '~~/server/utils/route-params'
+
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+  const userId = requireNumericIdParam(event, 'Member')
+  return getMemberRegistrations(db, userId)
+})

--- a/server/members/admin-overview.ts
+++ b/server/members/admin-overview.ts
@@ -1,0 +1,90 @@
+import type { db as hubDb } from 'hub:db'
+import { asc, count, eq } from 'drizzle-orm'
+import * as schema from '~~/server/db/schema'
+import { encodeEventId } from '~~/server/utils/sqids'
+import { memberSyncState, type MemberSyncState } from '~~/shared/utils/member-sync-state'
+
+type AppDb = typeof hubDb
+
+export type MemberAdminOverviewItem = {
+  id: number
+  firstName: string | null
+  lastName: string | null
+  email: string
+  avatarUrl: string | null
+  role: 'member' | 'admin' | 'superuser'
+  membershipStatus: 'active' | 'inactive' | null
+  membershipNumber: string | null
+  sections: string[] | null
+  hasLadvStartpass: boolean
+  syncState: MemberSyncState
+  lastSyncedAt: string | null
+  pushDeviceCount: number
+  registrationCount: number
+}
+
+export async function getMemberAdminOverview(
+  db: AppDb,
+  now: Date,
+): Promise<MemberAdminOverviewItem[]> {
+  const users = await db
+    .select()
+    .from(schema.users)
+    .orderBy(asc(schema.users.lastName), asc(schema.users.firstName))
+
+  const pushRows = await db
+    .select({ userId: schema.pushSubscriptions.userId, n: count() })
+    .from(schema.pushSubscriptions)
+    .groupBy(schema.pushSubscriptions.userId)
+  const pushByUser = new Map(pushRows.map(r => [r.userId, r.n]))
+
+  const regRows = await db
+    .select({ userId: schema.registrations.userId, n: count() })
+    .from(schema.registrations)
+    .groupBy(schema.registrations.userId)
+  const regByUser = new Map(regRows.map(r => [r.userId, r.n]))
+
+  return users.map(u => ({
+    id: u.id,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    email: u.email,
+    avatarUrl: u.avatarSmall ? `/api/avatar/${u.id}` : null,
+    role: u.role ?? 'member',
+    membershipStatus: u.membershipStatus,
+    membershipNumber: u.membershipNumber,
+    sections: u.sections,
+    hasLadvStartpass: u.hasLadvStartpass === 1,
+    syncState: memberSyncState({ campaiId: u.campaiId, lastSyncedAt: u.lastSyncedAt }, now),
+    lastSyncedAt: u.lastSyncedAt ? u.lastSyncedAt.toISOString() : null,
+    pushDeviceCount: pushByUser.get(u.id) ?? 0,
+    registrationCount: regByUser.get(u.id) ?? 0,
+  }))
+}
+
+export type MemberRegistrationItem = {
+  eventId: number
+  eventSlug: string
+  eventName: string
+  eventDate: string | null
+  status: string
+}
+
+export async function getMemberRegistrations(
+  db: AppDb,
+  userId: number,
+): Promise<MemberRegistrationItem[]> {
+  const rows = await db
+    .select({
+      eventId: schema.events.id,
+      eventName: schema.events.name,
+      eventDate: schema.events.date,
+      status: schema.registrations.status,
+    })
+    .from(schema.registrations)
+    .innerJoin(schema.events, eq(schema.registrations.eventId, schema.events.id))
+    .where(eq(schema.registrations.userId, userId))
+    .orderBy(asc(schema.events.date))
+
+  return rows.map(r => ({ ...r, eventSlug: encodeEventId(r.eventId) }))
+}

--- a/shared/utils/member-sync-state.ts
+++ b/shared/utils/member-sync-state.ts
@@ -1,0 +1,17 @@
+export type MemberSyncState = 'synced' | 'stale' | 'never'
+
+/**
+ * Ein Member gilt als "stale", wenn der letzte Campai-Sync länger als
+ * diese Spanne zurückliegt (Sync läuft regulär täglich).
+ */
+export const SYNC_STALE_AFTER_MS = 48 * 60 * 60 * 1000 // 48h
+
+export function memberSyncState(
+  input: { campaiId: string | null, lastSyncedAt: Date | null },
+  now: Date,
+): MemberSyncState {
+  if (!input.campaiId) return 'never'
+  if (!input.lastSyncedAt) return 'stale'
+  const age = now.getTime() - input.lastSyncedAt.getTime()
+  return age > SYNC_STALE_AFTER_MS ? 'stale' : 'synced'
+}

--- a/test/unit/server/members/admin-overview.test.ts
+++ b/test/unit/server/members/admin-overview.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { getMemberAdminOverview, getMemberRegistrations } from '~~/server/members/admin-overview'
+import { encodeEventId } from '~~/server/utils/sqids'
+import { createTestDb, type TestDb } from '../../../helpers/test-db'
+
+const NOW = new Date('2026-05-30T12:00:00Z')
+
+let testDb: TestDb
+let db: TestDb['db']
+
+beforeEach(async () => {
+  testDb = await createTestDb()
+  db = testDb.db
+})
+
+afterEach(async () => {
+  await testDb.cleanup()
+})
+
+type SeedUserOpts = {
+  firstName?: string
+  lastName?: string
+  role?: 'member' | 'admin' | 'superuser'
+  campaiId?: string | null
+  lastSyncedAt?: Date | null
+  membershipStatus?: 'active' | 'inactive'
+}
+
+let emailSeq = 0
+
+async function seedUser(opts: SeedUserOpts = {}): Promise<number> {
+  const { schema } = testDb
+  const [user] = await db.insert(schema.users).values({
+    email: `user${emailSeq++}@example.com`,
+    firstName: opts.firstName ?? 'Test',
+    lastName: opts.lastName ?? 'User',
+    role: opts.role ?? 'member',
+    campaiId: opts.campaiId ?? null,
+    lastSyncedAt: opts.lastSyncedAt ?? null,
+    membershipStatus: opts.membershipStatus ?? 'active',
+  }).returning()
+  return user.id
+}
+
+async function seedEvent(createdBy: number, opts: { name?: string, date?: string } = {}): Promise<number> {
+  const { schema } = testDb
+  const [event] = await db.insert(schema.events).values({
+    type: 'ladv',
+    name: opts.name ?? 'Test-Event',
+    date: opts.date ?? '2026-07-01',
+    registrationDeadline: '2026-06-20',
+    createdBy,
+  }).returning()
+  return event.id
+}
+
+async function seedPushDevice(userId: number, endpoint: string): Promise<void> {
+  const { schema } = testDb
+  await db.insert(schema.pushSubscriptions).values({
+    userId,
+    endpoint,
+    keysAuth: 'auth',
+    keysP256dh: 'p256dh',
+  })
+}
+
+async function seedRegistration(eventId: number, userId: number): Promise<void> {
+  const { schema } = testDb
+  await db.insert(schema.registrations).values({
+    eventId,
+    userId,
+    status: 'registered',
+  })
+}
+
+describe('getMemberAdminOverview', () => {
+  it('returns one item per user with derived sync state and zero counts', async () => {
+    const userId = await seedUser({
+      campaiId: 'c1',
+      lastSyncedAt: new Date(NOW.getTime() - 60 * 60 * 1000), // 1h ago
+    })
+
+    const result = await getMemberAdminOverview(db, NOW)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      id: userId,
+      syncState: 'synced',
+      pushDeviceCount: 0,
+      registrationCount: 0,
+    })
+  })
+
+  it('reports never for a member that was never synced from Campai', async () => {
+    await seedUser({ campaiId: null })
+    const [item] = await getMemberAdminOverview(db, NOW)
+    expect(item.syncState).toBe('never')
+  })
+
+  it('counts active push devices per member', async () => {
+    const userId = await seedUser()
+    await seedPushDevice(userId, 'https://push/1')
+    await seedPushDevice(userId, 'https://push/2')
+
+    const [item] = await getMemberAdminOverview(db, NOW)
+    expect(item.pushDeviceCount).toBe(2)
+  })
+
+  it('counts event registrations per member', async () => {
+    const userId = await seedUser()
+    const e1 = await seedEvent(userId)
+    const e2 = await seedEvent(userId)
+    await seedRegistration(e1, userId)
+    await seedRegistration(e2, userId)
+
+    const [item] = await getMemberAdminOverview(db, NOW)
+    expect(item.registrationCount).toBe(2)
+  })
+
+  it('orders members by last name, then first name', async () => {
+    await seedUser({ firstName: 'Anna', lastName: 'Zimmer' })
+    await seedUser({ firstName: 'Bea', lastName: 'Albers' })
+    await seedUser({ firstName: 'Carl', lastName: 'Albers' })
+
+    const names = (await getMemberAdminOverview(db, NOW)).map(m => `${m.lastName} ${m.firstName}`)
+    expect(names).toEqual(['Albers Bea', 'Albers Carl', 'Zimmer Anna'])
+  })
+})
+
+describe('getMemberRegistrations', () => {
+  it('lists the events a member is registered for, soonest first', async () => {
+    const userId = await seedUser()
+    const later = await seedEvent(userId, { name: 'Spätes Event', date: '2026-08-15' })
+    const sooner = await seedEvent(userId, { name: 'Frühes Event', date: '2026-07-01' })
+    await seedRegistration(later, userId)
+    await seedRegistration(sooner, userId)
+
+    const regs = await getMemberRegistrations(db, userId)
+
+    expect(regs.map(r => r.eventName)).toEqual(['Frühes Event', 'Spätes Event'])
+    expect(regs[0]).toMatchObject({ eventId: sooner, status: 'registered' })
+  })
+
+  it('exposes the encoded event id for linking to the event detail page', async () => {
+    const userId = await seedUser()
+    const eventId = await seedEvent(userId)
+    await seedRegistration(eventId, userId)
+
+    const [reg] = await getMemberRegistrations(db, userId)
+    expect(reg.eventSlug).toBe(encodeEventId(eventId))
+  })
+
+  it('returns an empty list for a member without registrations', async () => {
+    const userId = await seedUser()
+    expect(await getMemberRegistrations(db, userId)).toEqual([])
+  })
+})

--- a/test/unit/shared/utils/member-sync-state.test.ts
+++ b/test/unit/shared/utils/member-sync-state.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { memberSyncState } from '../../../../shared/utils/member-sync-state'
+
+const NOW = new Date('2026-05-30T12:00:00Z')
+
+describe('memberSyncState', () => {
+  it('reports never when the member has no campaiId', () => {
+    expect(memberSyncState({ campaiId: null, lastSyncedAt: NOW }, NOW)).toBe('never')
+  })
+
+  it('reports synced when the last sync is recent', () => {
+    const recent = new Date(NOW.getTime() - 1 * 60 * 60 * 1000) // 1h ago
+    expect(memberSyncState({ campaiId: 'c1', lastSyncedAt: recent }, NOW)).toBe('synced')
+  })
+
+  it('reports stale when the last sync is older than the threshold', () => {
+    const old = new Date(NOW.getTime() - 3 * 24 * 60 * 60 * 1000) // 3 days ago
+    expect(memberSyncState({ campaiId: 'c1', lastSyncedAt: old }, NOW)).toBe('stale')
+  })
+
+  it('reports stale when linked to Campai but never actually synced', () => {
+    expect(memberSyncState({ campaiId: 'c1', lastSyncedAt: null }, NOW)).toBe('stale')
+  })
+})


### PR DESCRIPTION
Read-only Member-Tabelle mit Filtern (Suche, Rolle, Push, Sync-Status) und Detail-Modal (Stammdaten + Event-Anmeldungen). Sync-Status-Util und Overview-Modul test-getrieben.

Closes #257